### PR TITLE
Display blog tags in blog details

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/BlogDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogDetailManager.cs
@@ -68,6 +68,11 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine();
             Console.WriteLine($"Blog title: {blog.Title}");
             Console.WriteLine($"URL: {blog.Url}");
+            Console.WriteLine("Tags:");
+            foreach (Tag tag in blog.Tags)
+            {
+                Console.WriteLine(" " + tag);
+            }
             Console.WriteLine();
         }
 

--- a/TabloidCLI/UserInterfaceManagers/BlogDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogDetailManager.cs
@@ -34,7 +34,7 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine(" 3) Remove Tag");
             Console.WriteLine(" 4) View posts");
             Console.WriteLine(" 0) Go Back");
-            Console.WriteLine();
+            Console.Write("> ");
 
 
 
@@ -92,7 +92,7 @@ namespace TabloidCLI.UserInterfaceManagers
         {
             Blog blog = _blogRepository.Get(_blogId);
 
-            Console.WriteLine($"Which tag would you like to add to {blog.Title}");
+            Console.WriteLine($"Which tag would you like to add to {blog.Title}?");
             List<Tag> tags = _tagRepository.GetAll();
             for (int i = 0; i < tags.Count; i++)
             {

--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -33,7 +33,7 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine(" 0) Go Back");
 
 
-            Console.WriteLine("> ");
+            Console.Write("> ");
             string choice = Console.ReadLine();
             switch (choice)
             {
@@ -116,7 +116,7 @@ namespace TabloidCLI.UserInterfaceManagers
                 Blog blog = blogs[i];
                 Console.WriteLine($" {i + 1}) {blog.Title}");
             }
-            Console.WriteLine("> ");
+            Console.Write("> ");
             string input = Console.ReadLine();
             try
             {

--- a/TabloidCLI/UserInterfaceManagers/SearchManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchManager.cs
@@ -44,6 +44,12 @@ namespace TabloidCLI.UserInterfaceManagers
             }
         }
 
+        private void SearchBlogs()
+        {
+            Console.Write("Tag > ");
+            string tagname = Console.ReadLine();
+
+        }
         private void SearchAuthors()
         {
             Console.Write("Tag> ");


### PR DESCRIPTION
Piggybacking off of Chris' extensive work on the blogs...

Similar to Author details now:
- viewing blog details shows a list of tags in addition to previous info

Would love if someone would add some tags to a blog and double check this for me.